### PR TITLE
server: Fix support for before/after date in APIs

### DIFF
--- a/packages/server/controllers/activity.controller.js
+++ b/packages/server/controllers/activity.controller.js
@@ -13,12 +13,13 @@ export const activity_create = (req, res, next) => {
 
 export const all_activities = (req, res, next) => {
 	const today = new Date();
-	const tomorrow = new Date(today);
-	tomorrow.setDate(tomorrow.getDate() + 1);
+	const yesterday = new Date(today);
+	yesterday.setDate(yesterday.getDate() - 1);
 
-	const after = req.query.after ?? today.getTime();
-	const before = req.query.before ?? tomorrow.getTime();
+	const after = req.query.after ?? yesterday.toISOString();
+	const before = req.query.before ?? today.toISOString();
 
+	// TODO: Paginate results
 	Activity.find(
 		{ startTime: { $gte: after, $lt: before } },
 		(err, activity) => {


### PR DESCRIPTION
## Description

- Use Date objects (instead of strings) in aggregate.match for gte and lt queries to work
- If before and after dates aren't provided through query params set them to today and yesterday respectively.