### PR TITLE
Feat: Emails for OTP

### DIFF
--- a/packages/desktop/src/getIcon.js
+++ b/packages/desktop/src/getIcon.js
@@ -1,6 +1,41 @@
-import { existsSync } from 'fs';
+import fs from 'fs';
+import path from 'path';
+import envPaths from 'env-paths';
+import fileIconExtractor from 'file-icon-extractor';
+const { extract } = fileIconExtractor;
 
-const getIcon = appName => {
+const defaultDir = envPaths('ActivityTracker').data;
+
+const iconsDir = path.join(defaultDir, '/icons');
+const filename = path.join(defaultDir, '/iconmapping.json');
+fs.mkdirSync(iconsDir, { recursive: true });
+
+function getIconsdata() {
+	let data = [];
+	try {
+		data = JSON.parse(fs.readFileSync(filename));
+	} catch (error) {
+		if (error.code === 'ENOENT') {
+			data = [];
+		} else {
+			throw error;
+		}
+	}
+	return data;
+}
+
+function containsObject(obj, list) {
+	var i;
+	for (i = 0; i < list.length; i++) {
+		if (JSON.stringify(list[i]) === JSON.stringify(obj)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+const getIcon = (appName, appPath) => {
 	if (process.platform === 'linux') {
 		const iconDirs = [
 			'/usr/share/pixmaps/',
@@ -10,7 +45,7 @@ const getIcon = appName => {
 		const iconPaths = iconDirs
 			.map(path => {
 				const fullPath = `${path}${appName.toLowerCase()}.png`;
-				return existsSync(fullPath) ? fullPath : null;
+				return fs.existsSync(fullPath) ? fullPath : null;
 			})
 			.filter(path => path !== null);
 
@@ -19,15 +54,31 @@ const getIcon = appName => {
 		}
 
 		return null;
+	} else if (process.platform === 'win32') {
+		let iconsData = getIconsdata();
+		var iconObj = {
+			[appName]: `${iconsDir}\\${appName}.png`.replace('.exe', ''),
+		};
+		if (containsObject(iconObj, iconsData)) {
+			return 'not extracted';
+		} else {
+			extract(appPath, iconsDir);
+			iconsData.push({
+				[appName]: `${iconsDir}\\${appName}.png`.replace('.exe', ''),
+			});
+			fs.writeFileSync(filename, JSON.stringify(iconsData));
+			console.log(iconsDir);
+			return `extracted ${appName}`;
+		}
 	} else {
 		try {
-			// import { extract } from 'file-icon-extractor';
-			// extract('/usr/bin/code');
-			throw new Error('Not Implemented icon extractor for Non-Linux OSes');
+			throw new Error('Not a supported OS currently');
 		} catch (error) {
 			return null;
 		}
 	}
 };
+
+// Extract singluar icon
 
 export default getIcon;

--- a/packages/desktop/src/index.js
+++ b/packages/desktop/src/index.js
@@ -1,7 +1,7 @@
 import { JSONStorage } from './storage/json.js';
 import { ServerStorage } from './storage/server.js';
 import { ActiveWindowWatcher } from './tracker.js';
-// import getIcon from './getIcon.js';
+import getIcon from './getIcon.js';
 
 const interval = 2000;
 
@@ -15,7 +15,7 @@ const activeWindowWatcher = new ActiveWindowWatcher(interval, activity => {
 		storage.saveActivity(activity);
 	}
 
-	// console.log(getIcon(activity.name));
+	console.log(getIcon(activity.name, activity.path));
 });
 
 activeWindowWatcher.initialize();

--- a/packages/desktop/src/storage/server.js
+++ b/packages/desktop/src/storage/server.js
@@ -9,12 +9,13 @@ export class ServerStorage {
 	}
 
 	saveActivity(activity) {
-		const { name, title, startTime, endTime } = activity;
+		const { name, path, title, startTime, endTime } = activity;
 
 		axios
 			.post(`${this.serverURL}/activities`, {
 				name,
 				title,
+				path,
 				startTime,
 				endTime,
 			})

--- a/packages/desktop/src/tracker.js
+++ b/packages/desktop/src/tracker.js
@@ -21,13 +21,14 @@ export class ActiveWindowWatcher {
 		const startTime = this.startTime;
 
 		const {
-			owner: { name },
+			owner: { name, path },
 			title,
 			url,
 		} = this.app;
 
 		const data = {
 			name,
+			path,
 			title: title ?? 'No Title',
 			url,
 			startTime,

--- a/packages/server/controllers/emailSender.js
+++ b/packages/server/controllers/emailSender.js
@@ -1,0 +1,55 @@
+import nodemailer from 'nodemailer';
+import googleapis from 'googleapis';
+const { google } = googleapis;
+const OAuth2 = google.auth.OAuth2;
+
+//tokens generated from google authenticator
+const clientId =
+	'972207074661-sur9ghdgj3uocmmj1lp7s79gqftd6ok1.apps.googleusercontent.com';
+const clientSecret = 'TVnIb89BdddWZnvHUQpBO6Oh';
+const redirectUrl = 'https://developers.google.com/oauthplayground';
+const refreshToken =
+	'1//04h4QwqkGF8B9CgYIARAAGAQSNwF-L9Ir1KCIMMRR8wr8cev6GKN55ohFgKDCAh17ZCjg-Br_ehP1Kdw7DvBgE3sBN5oWjcA8FmQ';
+
+//new Authorized client
+const OAuth2Client = new OAuth2(clientId, clientSecret, redirectUrl);
+OAuth2Client.setCredentials({ refresh_token: refreshToken });
+
+export async function emailSender(receiverEmail) {
+	// TODO: Send actual OTP using nodemailer
+	try {
+		//getting the access token each time to send emails
+		const accessToken = await OAuth2Client.getAccessToken();
+
+		//Create a transport meduim for emails
+		const transport = nodemailer.createTransport({
+			service: 'gmail',
+			auth: {
+				type: 'OAuth2',
+				user: 'activitytrackercpat@gmail.com',
+				clientId: clientId,
+				clientSecret: clientSecret,
+				refreshToken: refreshToken,
+				accessToken: accessToken,
+			},
+			tls: {
+				rejectUnauthorized: false,
+			},
+		});
+
+		//email option
+		const mailOptions = {
+			from: 'Activity Tracker <activitytrackercpat@gmail.com>',
+			to: receiverEmail,
+			subject: 'Hello from Activity Tracker',
+			text: 'Hello',
+			html: '<b>Your OTP is 123456<b/>',
+		};
+
+		//Send the emails
+		const info = await transport.sendMail(mailOptions);
+		return info;
+	} catch (error) {
+		return error;
+	}
+}

--- a/packages/server/controllers/user.controller.js
+++ b/packages/server/controllers/user.controller.js
@@ -1,10 +1,14 @@
 import { User, registerValidate, loginValidate } from '../models/user.model.js';
 import Device from '../models/device.model.js';
 import bcrypt from 'bcrypt';
+import { emailSender } from './emailSender.js';
 
-const sendOtp = user => {
+export const sendOtp = async user => {
 	// TODO: Send actual OTP using nodemailer
-	return 'DEFAULT_OTP';
+	//send email to user for otp
+	emailSender(user.email)
+		.then(result => console.log('Email sent', result))
+		.catch(error => console.log(error.message));
 };
 
 export const register_user = async (req, res) => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,6 +14,7 @@
 		"cors": "^2.8.5",
 		"dotenv": "^10.0.0",
 		"express": "^4.17.1",
+		"googleapis": "^86.1.0",
 		"joi": "^17.4.2",
 		"jsonwebtoken": "^8.5.1",
 		"mongoose": "^5.13.3",


### PR DESCRIPTION
## Description

This will send the otp to users for registration, created with google apis and nodemailer with OAuth2 authentication.<br />

Fixes #[ISSUENO]

## Dependencies

1. nodemailer
2. googleapis

## Future Improvements

1. Need a way to generate random otp's

## Mentions

@KShivendu @supercoww 

## Screenshots of relevant screens

_Add screenshots of relevant screens_

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues
